### PR TITLE
Add Playwright UI testing and GitHub Actions

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -23,6 +23,7 @@ jobs:
     env:
       NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ vars.NEXT_PUBLIC_SANITY_PROJECT_ID }}
       NEXT_PUBLIC_SANITY_DATASET: ${{ vars.NEXT_PUBLIC_SANITY_DATASET }}
+      SANITY_API_READ_TOKEN: ${{ secrets.SANITY_API_READ_TOKEN }}
 
     steps:
       - name: Check out repository

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -19,9 +19,13 @@ jobs:
   test:
     name: Playwright
     if: >-
-      github.event_name == 'push' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.author_association == 'OWNER'
+      ${{
+        github.event_name == 'push' ||
+        contains(
+          fromJSON('["MEMBER", "OWNER"]'),
+          github.event.pull_request.author_association
+        )
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -18,14 +18,6 @@ concurrency:
 jobs:
   test:
     name: Playwright
-    if: >-
-      ${{
-        github.event_name == 'push' ||
-        contains(
-          fromJSON('["MEMBER", "OWNER"]'),
-          github.event.pull_request.author_association
-        )
-      }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -1,0 +1,56 @@
+name: UI Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ui-tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Playwright
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.author_association == 'MEMBER' ||
+      github.event.pull_request.author_association == 'OWNER'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ vars.NEXT_PUBLIC_SANITY_PROJECT_ID }}
+      NEXT_PUBLIC_SANITY_DATASET: ${{ vars.NEXT_PUBLIC_SANITY_DATASET }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run UI tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v5
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 
 # testing
 /coverage
+/playwright-report/
+/test-results/
+/blob-report/
 
 # next.js
 /.next/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,4 +50,5 @@ repository requires approval for workflow runs from all external contributors,
 so only organization members and owners run PR workflows automatically.
 Repository variables named `NEXT_PUBLIC_SANITY_PROJECT_ID` and
 `NEXT_PUBLIC_SANITY_DATASET` provide the public Sanity connection settings in
-CI.
+CI. The read-only `SANITY_API_READ_TOKEN` repository secret allows the test
+server to query Sanity content.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing
+
+## Local setup
+
+Install dependencies and copy the example environment file:
+
+```bash
+npm install
+cp .env.local.example .env.local
+```
+
+Add the required Sanity project ID and dataset to `.env.local`, then start the
+development server with `npm run dev`.
+
+## UI tests
+
+The end-to-end suite uses Playwright and covers the homepage, primary
+navigation, donation destination, contact-form validation, and desktop/mobile
+layouts.
+
+Install Chromium once after installing the project dependencies:
+
+```bash
+npx playwright install chromium
+```
+
+Run the full suite:
+
+```bash
+npm run test:e2e
+```
+
+Playwright starts the Next.js development server automatically. If a server is
+already running on port 3000, the local test run reuses it. To run and debug
+tests interactively:
+
+```bash
+npm run test:e2e:ui
+```
+
+Failed runs write traces, screenshots, and videos to `test-results/`. The HTML
+report is written to `playwright-report/` and can be opened with:
+
+```bash
+npx playwright show-report
+```
+
+GitHub Actions runs the suite for pushes to `main`. For pull requests, the job
+runs only when GitHub identifies the author as an organization member or owner;
+other pull-request runs are skipped. Repository variables named
+`NEXT_PUBLIC_SANITY_PROJECT_ID` and `NEXT_PUBLIC_SANITY_DATASET` provide the
+public Sanity connection settings in CI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,9 @@ report is written to `playwright-report/` and can be opened with:
 npx playwright show-report
 ```
 
-GitHub Actions runs the suite for pushes to `main`. For pull requests, the job
-runs only when GitHub identifies the author as an organization member or owner;
-other pull-request runs are skipped. Repository variables named
-`NEXT_PUBLIC_SANITY_PROJECT_ID` and `NEXT_PUBLIC_SANITY_DATASET` provide the
-public Sanity connection settings in CI.
+GitHub Actions runs the suite for pushes to `main` and pull requests. The
+repository requires approval for workflow runs from all external contributors,
+so only organization members and owners run PR workflows automatically.
+Repository variables named `NEXT_PUBLIC_SANITY_PROJECT_ID` and
+`NEXT_PUBLIC_SANITY_DATASET` provide the public Sanity connection settings in
+CI.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This starter is a statically generated personal website that uses [Next.js][next
 The Studio connects to Sanity Content Lake, which gives you hosted content APIs with a flexible query language, on-demand image transformations, powerful patching, and more. You can use this starter to kick-start a personal website or learn these technologies.
 
 [![Deploy with Vercel](https://vercel.com/button)][vercel-deploy]
+[![UI Tests](https://github.com/Pine-Island-Food-Pantry-Site/main-website/actions/workflows/ui-tests.yml/badge.svg)](https://github.com/Pine-Island-Food-Pantry-Site/main-website/actions/workflows/ui-tests.yml)
 
 ## Features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^2.5.5",
+				"@playwright/test": "^1.62.0",
 				"@tailwindcss/postcss": "^4.3.3",
 				"@types/node": "^26.1.1",
 				"@types/react": "^19.2.17",
@@ -4628,6 +4629,22 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/@playwright/test": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+			"integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright": "1.62.0"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/@pnpm/config.env-replace": {
@@ -12988,6 +13005,53 @@
 			],
 			"dependencies": {
 				"media-chrome": "~4.19.0"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+			"integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.62.0"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.62.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+			"integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/pluralize-esm": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
 		"lint": "npx biome check",
 		"lint:fix": "npx biome check --apply",
 		"start": "next start",
+		"test:e2e": "playwright test",
+		"test:e2e:ui": "playwright test --ui",
 		"type-check": "tsc --noEmit"
 	},
 	"dependencies": {
@@ -35,6 +37,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.5",
+		"@playwright/test": "^1.62.0",
 		"@tailwindcss/postcss": "^4.3.3",
 		"@types/node": "^26.1.1",
 		"@types/react": "^19.2.17",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+	testDir: './tests/e2e',
+	fullyParallel: true,
+	forbidOnly: Boolean(process.env.CI),
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: process.env.CI
+		? [['line'], ['html', { open: 'never' }]]
+		: [['list'], ['html', { open: 'on-failure' }]],
+	use: {
+		baseURL: 'http://127.0.0.1:3000',
+		screenshot: 'only-on-failure',
+		trace: 'on-first-retry',
+		video: 'on-first-retry',
+	},
+	projects: [
+		{
+			name: 'desktop-chromium',
+			use: { ...devices['Desktop Chrome'] },
+		},
+		{
+			name: 'mobile-chromium',
+			use: { ...devices['Pixel 5'] },
+		},
+	],
+	webServer: {
+		command: 'npm run dev -- --hostname 127.0.0.1',
+		url: 'http://127.0.0.1:3000',
+		reuseExistingServer: !process.env.CI,
+		timeout: 180_000,
+	},
+})

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('Pine Island Food Pantry', () => {
+	test('homepage loads its core content', async ({ page }) => {
+		const response = await page.goto('/')
+
+		expect(response?.ok()).toBe(true)
+		await expect(
+			page.getByRole('heading', {
+				level: 1,
+				name: 'Welcome to The Pine Island Food Pantry',
+			}),
+		).toBeVisible()
+		await expect(
+			page.getByRole('img', { name: 'Pine Island Food Pantry Logo' }),
+		).toBeVisible()
+		await expect(
+			page.getByRole('heading', { level: 3, name: 'Our Mission' }),
+		).toBeVisible()
+	})
+
+	test('primary navigation reaches the contact page', async ({ page }) => {
+		await page.goto('/')
+		await page.getByRole('link', { name: 'Contact', exact: true }).click()
+
+		await expect(page).toHaveURL(/\/contact$/)
+		await expect(
+			page.getByRole('heading', {
+				level: 1,
+				name: 'The Pine Island Food Pantry',
+			}),
+		).toBeVisible()
+		await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible()
+	})
+
+	test('donation link points to the secure donation flow', async ({ page }) => {
+		await page.goto('/')
+
+		const donateLink = page.getByRole('link', { name: 'Donate', exact: true })
+		await expect(donateLink).toHaveAttribute(
+			'href',
+			'https://www.paypal.com/donate?hosted_button_id=45JBRR8VRXJ76',
+		)
+		await expect(donateLink).toHaveAttribute('target', '_blank')
+	})
+
+	test('contact form validates required fields without submitting', async ({
+		page,
+	}) => {
+		await page.goto('/contact')
+		await page.getByRole('button', { name: 'Submit' }).click()
+
+		await expect(page.getByText('Full name is required')).toBeVisible()
+		await expect(page.getByText('Enter your email')).toBeVisible()
+		await expect(page.getByText('Enter your phone number')).toBeVisible()
+		await expect(page.getByText('Enter your Message')).toBeVisible()
+	})
+
+	test('navigation adapts to desktop and mobile viewports', async ({
+		page,
+	}, testInfo) => {
+		await page.goto('/')
+
+		const navigation = page
+			.getByRole('link', { name: 'Donate', exact: true })
+			.locator('..')
+		const isMobile = testInfo.project.name === 'mobile-chromium'
+
+		await expect(navigation).toHaveCSS(
+			'position',
+			isMobile ? 'fixed' : 'relative',
+		)
+		await expect(
+			page.getByRole('link', { name: 'Contact', exact: true }),
+		).toBeVisible()
+	})
+})


### PR DESCRIPTION
## Summary

- add Playwright coverage for the homepage, navigation, donation destination, contact form validation, and responsive layouts
- run UI tests on pushes to main and PRs authored by organization members or owners
- upload Playwright reports and document local test commands
- add the UI test status badge to the README

## Testing

- `npm run test:e2e` (10 passed)
- `npm run type-check`
- `npx biome check package.json playwright.config.ts tests/e2e/site.spec.ts`

## Notes

Repository-wide `npm run lint` still reports pre-existing diagnostics outside this change.

Closes #22